### PR TITLE
Bump OTA Provider to 2025.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 
 ARG PYTHON_MATTER_SERVER
 
-ENV chip_example_url "https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/download/2025.5.0"
+ENV chip_example_url "https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/download/2025.9.0"
 ARG TARGETPLATFORM
 
 RUN \


### PR DESCRIPTION
This updates the OTA provider to the latest v1.4.2-branch version of the Matter SDK.

See [2025.9.0 change log](https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/tag/2025.9.0).