### PR TITLE
Update release drafter workflow permission

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: read  # for release-drafter/release-drafter to read PR content and labels
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"


### PR DESCRIPTION
With the move to the matter-js org restrictive GitHub Action permissions are used. To make the release drafter workflow still work explicit permission need to be requested.